### PR TITLE
Add merit path in overview for sessions 1 to 3

### DIFF
--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -1,20 +1,28 @@
-# Overview
+# Merit Path for Sessions 1 to 3
 
-## Introduction
+## Merit Path Overview
 
-Welcome to the College Training - Yatri Cloud project. This project aims to provide comprehensive training and resources for college students to enhance their skills in cloud computing and DevOps. Our goal is to bridge the gap between academic knowledge and industry requirements by offering hands-on experience and practical knowledge.
+The merit path for sessions 1 to 3 is designed to provide students with a structured learning experience, focusing on key topics and practical skills. Each session builds upon the previous one, ensuring a comprehensive understanding of the subject matter.
 
-## Key Features
+## Session 1: Introduction to System Administration & User Management
 
-- **Comprehensive Curriculum**: Our training program covers a wide range of topics, including cloud computing, DevOps, system administration, and more.
-- **Hands-On Labs**: We provide practical labs and exercises to help students apply their knowledge in real-world scenarios.
-- **Expert Instructors**: Our team of experienced instructors and industry professionals guide students through the learning process.
-- **Community Support**: Students can join our community forums and discussion groups to collaborate and seek help from peers and mentors.
-- **Certification**: Upon completion of the training program, students receive a certification that validates their skills and knowledge.
+### Key Topics:
+- Introduction to Linux and Windows system administration
+- User management in Linux and Windows
+- Hands-on exercises for creating and managing user accounts
 
-## Project Goals and Objectives
+## Session 2: Security for Exams
 
-- **Skill Development**: Equip students with the necessary skills to excel in cloud computing and DevOps roles.
-- **Industry Readiness**: Prepare students for the demands of the industry by providing practical experience and knowledge.
-- **Career Advancement**: Help students advance their careers by offering certification and recognition for their achievements.
-- **Continuous Learning**: Encourage continuous learning and professional development through ongoing training and resources.
+### Key Topics:
+- Implementing security measures for exam environments
+- Configuring file and folder permissions
+- Using ACLs (Access Control Lists) for fine-grained access control
+- Hands-on exercises for setting up security configurations
+
+## Session 3: Networking Basics
+
+### Key Topics:
+- Understanding IP addressing and subnetting
+- Configuring DHCP and DNS servers
+- Setting up a local network with multiple machines
+- Hands-on exercises for network setup and troubleshooting


### PR DESCRIPTION
Update `pages/index.mdx` to add a merit path for sessions 1 to 3 and remove existing content in the overview section.

* **Merit Path Overview**
  - Add a new section titled "Merit Path for Sessions 1 to 3"
  - Include a brief description of the merit path

* **Session 1: Introduction to System Administration & User Management**
  - Add key topics: Introduction to Linux and Windows system administration, user management in Linux and Windows, hands-on exercises for creating and managing user accounts

* **Session 2: Security for Exams**
  - Add key topics: Implementing security measures for exam environments, configuring file and folder permissions, using ACLs for fine-grained access control, hands-on exercises for setting up security configurations

* **Session 3: Networking Basics**
  - Add key topics: Understanding IP addressing and subnetting, configuring DHCP and DNS servers, setting up a local network with multiple machines, hands-on exercises for network setup and troubleshooting

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yatricloud/collegetraining-yatri/pull/2?shareId=cfcbaee9-6417-4f39-a71e-304de2df6087).